### PR TITLE
Update 02-knn.R

### DIFF
--- a/scripts/tema4/02-knn.R
+++ b/scripts/tema4/02-knn.R
@@ -72,7 +72,7 @@ rmse.reg <- sqrt(mean(reg$residuals^2))
 rmse.reg
 
 ##Función para automatizar KNN
-rda.knn.reg <- function(tr_predictor, val_predictors,
+rdacb.knn.reg <- function(tr_predictor, val_predictors,
                           tr_target, val_target, k){
   library(FNN)
   res <- knn.reg(tr_predictor, val_predictors,


### PR DESCRIPTION
sin ese cambio al correr el codigo daria el siguiente mensaje : "Error in rdacb.knn.reg(tr_predictors, val_predictors, tr_target, val_target,  : 
  no se pudo encontrar la función "rdacb.knn.reg""